### PR TITLE
Upgrade to v4 of `actions/setup-python`

### DIFF
--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install CumulusCI

--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -1,15 +1,17 @@
 name: Tests
 
 on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened] # Default
   push:
     branches:
       - main
-      - feature/**
 
 jobs:
   tests:
     name: run feature tests
-    runs-on: macos-latest
+    runs-on: sfdc-ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python 3.8


### PR DESCRIPTION
Additional changes for this file:
- Run on PR synchonize regardless of branch name
- Switch to ubuntu premium runner (macos runners will stop working 2022-08-31)